### PR TITLE
Log in with username or email address

### DIFF
--- a/linkstack/app/Http/Requests/Auth/LoginRequest.php
+++ b/linkstack/app/Http/Requests/Auth/LoginRequest.php
@@ -29,7 +29,7 @@ class LoginRequest extends FormRequest
     public function rules()
     {
         return [
-            'email' => 'required|string|email',
+            'email' => 'required|string',       // Doesn't have to be a valid email - it might be a user name
             'password' => 'required|string',
         ];
     }
@@ -45,7 +45,10 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt(['email' => $this->email, 'password' => $this->password, 'block' => 'no'] , $this->filled('remember'))) {
+        // Allow either an email address or the user name to be entered in to the "email" field
+        
+        if (! (Auth::attempt(['email' => $this->email, 'password' => $this->password, 'block' => 'no'] , $this->filled('remember')
+            || Auth::attempt(['littlelink_name' => $this->email, 'password' => $this->password, 'block' => 'no'] , $this->filled('remember'))))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/linkstack/resources/lang/en/messages.php
+++ b/linkstack/resources/lang/en/messages.php
@@ -51,7 +51,7 @@ return [
   # Login Page
   'Sign In' => 'Sign In',
   'Login to stay connected' => 'Login to stay connected',
-  'Email' => 'Email',
+  'Email' => 'Username or email',
   'Password' => 'Password',
   'Remember Me' => 'Remember Me',
   'Forgot Password?' => 'Forgot Password?',

--- a/linkstack/resources/views/auth/login.blade.php
+++ b/linkstack/resources/views/auth/login.blade.php
@@ -50,7 +50,7 @@ foreach($pages as $page)
                   <div class="col-lg-12">
                     <div class="form-group">
                       <label for="email" class="form-label">{{__('messages.Email')}}</label>
-                      <input type="email" class="form-control" id="email" name="email" aria-describedby="email" placeholder=" " :value="old('email')" required autofocus >
+                      <input type="text" class="form-control" id="email" name="email" aria-describedby="email" placeholder=" " :value="old('email')" required autofocus >
                     </div>
                   </div>
                   <div class="col-lg-12">


### PR DESCRIPTION
To log in with username or email, three changes need to be made:
- Allow the form field to validate as text rather than email address
- Change the input prompt to "Username or email"
- Make the authorization attempt by looking up the value in both the email and username fields, allowing authorization if there's a match in either one

At some point we should be sure users can't create a username that's a valid email address, to prevent them from creating a username that's the same as someone else's email, but that's probably pretty low risk.