### PR TITLE
Dashboard Admin cards React replacment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ npm-debug.log
 yarn-error.log
 _ide_*
 **/.DS_Store
+/docker
+docker-compose.dev.yml

--- a/linkstack/resources/js/components/ActiveUsers.tsx
+++ b/linkstack/resources/js/components/ActiveUsers.tsx
@@ -1,6 +1,6 @@
 import Card from "./core/Card"
 
-export default function DashboardActiveUsers(props) {
+export default function DashboardActiveUsers(props :any) {
   const { users } = props;
 
   return (

--- a/linkstack/resources/js/components/ActiveUsers.tsx
+++ b/linkstack/resources/js/components/ActiveUsers.tsx
@@ -1,0 +1,32 @@
+import Card from "./core/Card"
+
+export default function DashboardActiveUsers(props) {
+  const { users } = props;
+
+  return (
+    <Card>
+        <div className="mb-3 text-gray-800 text-center p-4 w-full">
+          <div className='font-weight-bold text-left h3'>Active Users:</div><br></br>
+          <div className="d-flex flex-wrap justify-content-around">
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { users.updatedLast30DaysCount } </strong></h3>
+                  <span className="text-muted">Last 30 days'</span>
+              </div>
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { users.updatedLast7DaysCount } </strong></h3>
+                  <span className="text-muted">Last 7 days</span>
+              </div>
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { users.updatedLast24HrsCount }</strong></h3>
+                  <span className="text-muted">Last 24 hours</span>
+              </div>
+
+          </div>
+      </div>
+    </Card>
+        
+  );
+}

--- a/linkstack/resources/js/components/Registrations.tsx
+++ b/linkstack/resources/js/components/Registrations.tsx
@@ -1,0 +1,32 @@
+import Card from "./core/Card"
+
+export default function DashboardRegistrations(props) {
+  const { registrations } = props;
+
+  return (
+    <Card>
+        <div className="mb-3 text-gray-800 text-center p-4 w-full">
+          <div className='font-weight-bold text-left h3'>Registrations:</div><br></br>
+          <div className="d-flex flex-wrap justify-content-around">
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { registrations.lastMonthCount } </strong></h3>
+                  <span className="text-muted">Last 30 days'</span>
+              </div>
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { registrations.lastWeekCount } </strong></h3>
+                  <span className="text-muted">Last 7 days</span>
+              </div>
+
+              <div className="p-2">
+                  <h3 className="text-primary"><strong> { registrations.last24HrsCount }</strong></h3>
+                  <span className="text-muted">Last 24 hours</span>
+              </div>
+
+          </div>
+      </div>
+    </Card>
+        
+  );
+}

--- a/linkstack/resources/js/components/Registrations.tsx
+++ b/linkstack/resources/js/components/Registrations.tsx
@@ -1,6 +1,6 @@
 import Card from "./core/Card"
 
-export default function DashboardRegistrations(props) {
+export default function DashboardRegistrations(props :any) {
   const { registrations } = props;
 
   return (

--- a/linkstack/resources/js/components/Statistics.tsx
+++ b/linkstack/resources/js/components/Statistics.tsx
@@ -1,6 +1,6 @@
 import Card from "./core/Card"
 
-export default function DashboardStatistics(props) {
+export default function DashboardStatistics(props :any) {
   const { stats } = props;
 
   return (

--- a/linkstack/resources/js/components/Statistics.tsx
+++ b/linkstack/resources/js/components/Statistics.tsx
@@ -1,0 +1,32 @@
+import Card from "./core/Card"
+
+export default function DashboardStatistics(props) {
+  const { stats } = props;
+
+  return (
+    <Card>
+        <div className="mb-3 text-gray-800 text-center p-4 w-full">
+            <div className='font-weight-bold text-left h3'>Site Statistics:</div><br></br>
+            <div className="d-flex flex-wrap justify-content-around">
+
+                <div className="p-2">
+                    <h3 className="text-primary"><strong><i className="bi bi-share-fill"> { stats.siteLinks }  </i></strong></h3>
+                    <span className="text-muted">Total links</span>
+                </div>
+
+                <div className="p-2">
+                    <h3 className="text-primary"><strong><i className="bi bi-eye-fill"> { stats.siteClicks } </i></strong></h3>
+                    <span className="text-muted">Total clicks</span>
+                </div>
+
+                <div className="p-2">
+                    <h3 className="text-primary"><strong><i className="bi bi bi-person-fill"> { stats.userNumber }</i></strong></h3>
+                    <span className="text-muted">Total users</span>
+                </div>
+
+            </div>
+        </div>
+    </Card>
+        
+  );
+}

--- a/linkstack/resources/js/components/core/Card.tsx
+++ b/linkstack/resources/js/components/core/Card.tsx
@@ -1,0 +1,16 @@
+
+export default function Card(props) {
+    return (
+        <div className="col-lg-12">
+            <div className="card rounded">
+                <div className="card-body">
+                    <div className="row">
+                        <div className="col-sm-12">
+                            {props.children}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/linkstack/resources/js/components/core/Card.tsx
+++ b/linkstack/resources/js/components/core/Card.tsx
@@ -1,5 +1,5 @@
 
-export default function Card(props) {
+export default function Card(props :any) {
     return (
         <div className="col-lg-12">
             <div className="card rounded">

--- a/linkstack/resources/js/components/index.tsx
+++ b/linkstack/resources/js/components/index.tsx
@@ -12,6 +12,9 @@ import "./index.css";
 import Campaign from "./Campaign";
 import Spotify from "./Spotify";
 import Web3ConnectButton from "./Connect";
+import DashboardStatistics from "./Statistics";
+import DashboardRegistrations from "./Registrations";
+import DashboardActiveUsers from "./ActiveUsers";
 import { addwallet } from "../repository";
 
 const projectId =
@@ -183,6 +186,45 @@ if (hasCampaignComponent) {
   root.render(
     <App>
       <Campaign />
+    </App>
+  );
+}
+
+const hasStatisticsComponent = document.getElementById("stats-react");
+if (hasStatisticsComponent) {
+  const element = document.getElementById("stats-react") as HTMLElement;
+  const root = ReactDOM.createRoot(element);
+  const data = {...element.dataset};
+
+  root.render(
+    <App>
+      <DashboardStatistics stats={data} />
+    </App>
+  );
+}
+
+const hasRegistrationsComponent = document.getElementById("registrations-react");
+if (hasRegistrationsComponent) {
+  const element = document.getElementById("registrations-react") as HTMLElement;
+  const root = ReactDOM.createRoot(element);
+  const data = {...element.dataset};
+
+  root.render(
+    <App>
+      <DashboardRegistrations registrations={data} />
+    </App>
+  );
+}
+
+const hasActiveUsersComponent = document.getElementById("activeUsers-react");
+if (hasActiveUsersComponent) {
+  const element = document.getElementById("activeUsers-react") as HTMLElement;
+  const root = ReactDOM.createRoot(element);
+  const data = {...element.dataset};
+
+  root.render(
+    <App>
+      <DashboardActiveUsers users={data} />
     </App>
   );
 }

--- a/linkstack/resources/views/panel/index.blade.php
+++ b/linkstack/resources/views/panel/index.blade.php
@@ -85,7 +85,36 @@
     </div>
     @endif
 
-       <div class="col-lg-12">
+    @if(auth()->user()->role == 'admin' && !config('linkstack.single_user_mode'))
+    <div 
+        id="stats-react" 
+        data-site-links={{ $siteLinks }} 
+        data-site-clicks={{ $siteClicks }} 
+        data-user-number={{ $userNumber }} 
+    >
+        Stats
+    </div>
+
+    <div 
+        id="registrations-react" 
+        data-last-month-count={{ $lastMonthCount }} 
+        data-last-week-count={{ $lastWeekCount }} 
+        data-last24-hrs-count={{ $last24HrsCount }} 
+    >
+        Reg
+    </div>
+
+    <div 
+        id="activeUsers-react"
+        data-updated-last30-days-count={{ $updatedLast30DaysCount }} 
+        data-updated-last7-days-count={{ $updatedLast7DaysCount }} 
+        data-updated-last24-hrs-count={{ $updatedLast24HrsCount }} 
+    >
+        Active
+    </div>
+    @endif
+
+    {{-- <div class="col-lg-12">
           <div class="card   rounded">
              <div class="card-body">
                 <div class="row">
@@ -189,8 +218,8 @@
               </div>
            </div>
         </div>
-     </div>
-     @endif
+     </div> 
+     @endif --}}
 
     </div>
     </div>


### PR DESCRIPTION
These are the first React replacements of existing php components. This replaces the three site data cards seen on the Dashboard if the user is an admin.

The replaced components looks identical to the current ones:
![image](https://github.com/user-attachments/assets/6540f796-fe42-41da-a971-d8ce18a87565)
