### PR TITLE
Only include the reward_business_id if it is part of the user form

### DIFF
--- a/linkstack/app/Http/Controllers/UserController.php
+++ b/linkstack/app/Http/Controllers/UserController.php
@@ -793,12 +793,17 @@ class UserController extends Controller {
       EnvEditor::editKey('HOME_URL', $pageName);
     }
 
-    User::where('id', $userId)->update([
+    $toUpdate = [
       'littlelink_name' => $pageName,
       'littlelink_description' => $pageDescription,
-      'name' => $name,
-      'reward_business_id' => $reward,
-    ]);
+      'name' => $name
+    ];
+
+    if (env('ENABLE_LOYALTY') == true){
+      $toUpdate['reward_business_id'] = $reward;
+    }
+
+    User::where('id', $userId)->update($toUpdate);
 
     if ($request->hasFile('image')) {
 


### PR DESCRIPTION
Users that had a manually added `reward_business_id` would lose this id on editing the User form. The existing reward id was omitted from the form due to the `ENABLE_LOYALTY` flag being false. 

Fixed by adding a check for the `ENABLE_LOYALTY` flag in the form save function.